### PR TITLE
Simple Low battery notification for Wireless device

### DIFF
--- a/ad2web/templates/keypad/index.html
+++ b/ad2web/templates/keypad/index.html
@@ -403,6 +403,14 @@
                         }
                     }
                 }
+                if( msg.message_type == 'rfx') {
+                    if( msg.battery == true) {
+                        str = msg.serial_number + ' Low Battery';
+                        $('#keypad-line2').css("color", "black");
+                        $('#keypad-line2').css("visibility", "visible");
+                        $('#keypad-line2').html(str);
+                    }
+                }
             });
 
 //lets make the buttons animate when we use keyboard


### PR DESCRIPTION
Recently had a wireless keyfob with a low battery - you should not that due to the way wireless works you will see your neighbours wireless devices that have a low battery.  Ideally this would be extended to add wireless device serial numbers in the config and only display wireless messages for known wireless devices