### PR TITLE
check for number before delaying notification

### DIFF
--- a/ad2web/notifications/types.py
+++ b/ad2web/notifications/types.py
@@ -12,6 +12,7 @@ import json
 import re
 import ssl
 import sys
+import numbers
 try:
     from chump import Application
     have_chump = True
@@ -86,8 +87,8 @@ class NotificationSystem(object):
                     message = self._build_message(type, **kwargs)
 
                     if message:
-                        if n.delay > 0 and type in (ZONE_FAULT, ZONE_RESTORE, BYPASS):
-                            message_send_time = time.mktime((datetime.datetime.combine(datetime.date.today(), datetime.datetime.time(datetime.datetime.now())) + datetime.timedelta(minutes=delay)).timetuple())
+                        if isinstance(n.delay, numbers.Number) and n.delay > 0 and type in (ZONE_FAULT, ZONE_RESTORE, BYPASS):
+                            message_send_time = time.mktime((datetime.datetime.combine(datetime.date.today(), datetime.datetime.time(datetime.datetime.now())) + datetime.timedelta(minutes=n.delay)).timetuple())
 
                             notify = {}
                             notify['notification'] = n


### PR DESCRIPTION
On my install, `delay` was in the `notification_settings` table as a null `int_value` but a `1` for `string_value`. This broke notifications since the `n.delay > 0` condition would be true but it would refer to a non-existent variable. Changing the variable in the `datetime.timedelta()` to `n.delay` failed as well since  `timedelta()` expects a number. So fix this, I added a type check to the head of the condition. This type check will work in Python 2.6+. 

I was not able to track down how the sqlite database got into a state where an int setting has a string val, but the form handler works as expected, validating against strings and floats and properly setting `int_value` on save.