### PR TITLE
Added the ability to configure listener port through environment

### DIFF
--- a/ad2web/api/views.py
+++ b/ad2web/api/views.py
@@ -54,7 +54,7 @@ def api_doc():
     #modify the host in the json to get their local fqdn if not alarmdecoder (using gunicorn port)
     host = socket.getfqdn()
     if host != 'alarmdecoder':
-        data['host'] = host + ':5000'
+        data['host'] = host + ':' + os.getenv('AD_LISTENER_PORT', '5000')
 
     data = jsonify(data)
     return data, OK

--- a/ad2web/decoder.py
+++ b/ad2web/decoder.py
@@ -76,7 +76,7 @@ decodersocket = Blueprint('sock', __name__, url_prefix='/socket.io')
 def create_decoder_socket(app):
     debugged_app = SocketIODebugger(app, namespace=DecoderNamespace)
 
-    return SocketIOServer(('', 5000), debugged_app, resource="socket.io")
+    return SocketIOServer(('', int(os.getenv('AD_LISTENER_PORT', '5000'))), debugged_app, resource="socket.io")
 
 class Decoder(object):
     """

--- a/ad2web/discovery.py
+++ b/ad2web/discovery.py
@@ -1,3 +1,4 @@
+import os
 import socket
 import struct
 import sys
@@ -60,7 +61,7 @@ class DiscoveryServer(threading.Thread):
 
         self._socket = sock
         self._expiration_time = 600
-        self._current_port = 5000
+        self._current_port = int(os.getenv('AD_LISTENER_PORT', '5000'))
         self._current_ip_address = self._get_ip_address()
         self._device_uuid = self._get_device_uuid()
         self._announcement_timestamp = 0


### PR DESCRIPTION
Just wondering if you're open to not hard-coding the listener port.  I'm also trying to understand why you are opening a separate port from the gunicorn port (which is configurable).  In running the webapp, it seems that all the pages work on either port, except the virtual keyboard API only works on port 5000, not on the gunicorn port.