### PR TITLE
Fix for invalid zone after scan

### DIFF
--- a/ad2web/templates/js/setup/enrollment.js
+++ b/ad2web/templates/js/setup/enrollment.js
@@ -397,6 +397,11 @@ function parseAUIMessage(prefix, value)
                 arr = hexVal.split("00");
                 if( arr.length < 3 )
                     return null;
+                
+                if (arr.length > 0 && arr[0].length % 2){
+                    arr[0] = hexVal.substring(0, arr[0].length +1);
+                    arr[1] = arr[1].substring(1, arr[1].length);
+                }
 
                 address = hexToAscii(arr[0]);
                 zone_type = hexToAscii(arr[1]);


### PR DESCRIPTION
This is to fix the issue where after a zone scan, the page crashes due to an invalid hex value e.g:
`  {
    "address": "1\u0003",
    "zone_type": "\u0003\u0003",
    "zone_device_type": "3",
    "zone_name": "Example"
  }`