### PR TITLE
Fix for scanning multiple zones bug

### DIFF
--- a/ad2web/templates/js/setup/enrollment.js
+++ b/ad2web/templates/js/setup/enrollment.js
@@ -216,7 +216,7 @@ async function getZoneData()
         for( j = 0; j < 30; j++ )
         {
             await sleep(1500);
-            decoder.emit('keypress', 'K01|006f620c4549f5' + partition + 'fb4543f5' + asciiToHex(String.fromCharCode(30 + j)) + 'fb436c\r\n');
+            decoder.emit('keypress', 'K01|006f620c4549f5' + partition + 'fb4543f5' + decToHex(j) + 'fb436c\r\n');
         }
         progress(Math.floor(100/parseInt(partitionCount)));
     } 
@@ -240,21 +240,8 @@ async function checkDeviceLogs(numLogs)
     countLogEntries = 0;
     for( i = 1; i <= parseInt(numLogs); i++)
     {
-        strHex = '';
-        if( i < 10 )
-        {
-            strHex = asciiToHex("00" + i.toString());
-        }
-        else if( i > 10 && i < 100)
-        {
-            strHex = asciiToHex("0" + i.toString());
-        }
-        else
-        {
-            strHex = asciiToHex(i.toString());
-        }
         countLogEntries++;
-        decoder.emit('keypress', 'K01|00696b094549f530fb454af53134fb4543f5' + strHex + 'fb436c\r\n');
+        decoder.emit('keypress', 'K01|00696b094549f530fb454af53134fb4543f5' + decToHex(i) + 'fb436c\r\n');
         await sleep(1500);
     }
 }
@@ -265,6 +252,7 @@ async function checkDevices(numDevices)
     percent = 0;
     for( i = 1; i <= parseInt(numDevices); i++ )
     {
+        //TODO: might be a bug here (not tested). May want to replace strHex with decToHex(i) if # of devices > 9
         strHex = '';
 
         if( i < 10 )
@@ -292,6 +280,23 @@ function hexToAscii(str)
         ret += String.fromCharCode(parseInt(hex.substr(n, 2), 16));
     }
 
+    return ret;
+}
+
+function decToHex(num){
+    var ret = '';
+    if( num < 10 )
+    {
+        ret = asciiToHex("00" + num.toString());
+    }
+    else if( num > 10 && num < 100)
+    {
+        ret = asciiToHex("0" + num.toString());
+    }
+    else
+    {
+        ret = asciiToHex(num.toString());
+    }
     return ret;
 }
 


### PR DESCRIPTION
Found a bug when I scanned zones. Only 9 zones within a specific number range (e.g. zone 9 to 17) would show up. This is because the numbers getting converted from 0 to 29, were not being converted correctly, therefore, sent in an unexpected format e.g. / ; etc..

I re-used and refactored some of the code to address the issue. It looks like the issue might be present in another section of the code. I added a TODO with a note in case someone ever hits it and wants to update the code. 

Testing locally zones 9-31 and zone 99, now show up correctly.