### PR TITLE
Fix stacking timestamp in email subject bug

### DIFF
--- a/ad2web/notifications/types.py
+++ b/ad2web/notifications/types.py
@@ -339,9 +339,10 @@ class EmailNotification(BaseNotification):
             msg = MIMEText(text)
 
             if self.suppress_timestamp == False:
-                self.subject = self.subject + " (" + message_timestamp + ")"
+                msg['Subject'] = self.subject + " (" + message_timestamp + ")"
+            else:
+                msg['Subject'] = self.subject
 
-            msg['Subject'] = self.subject
             msg['From'] = self.source
             recipients = re.split('\s*;\s*|\s*,\s*', self.destination)
             msg['To'] = ', '.join(recipients)


### PR DESCRIPTION
In each email, the subject line would have old timestamps in it and the new timestamp would be stacked on to the end. This fix was tested and worked on my pi.