### PR TITLE
setup: fix incorrect exception syntax

### DIFF
--- a/ad2web/setup/views.py
+++ b/ad2web/setup/views.py
@@ -436,7 +436,7 @@ def device():
             try:
                 current_app.decoder.close()
                 current_app.decoder.open()
-            except ex as Exception:
+            except:
                 pass
 
             panel_mode = Setting.get_by_name('panel_mode').value


### PR DESCRIPTION
This is a fix for the error I'm encountering during setup in https://github.com/nutechsoftware/alarmdecoder-webapp/issues/36. This does not fix the second issue where the device cannot be opened. 