### PR TITLE
Pin Flask version to 0.12.4 as a temporary solution to use deprecated flask.ext imports

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Babel>=1.3
-Flask>=0.10.1
+Flask==0.12.4
 Flask-Babel>=0.9
 Flask-Cache>=0.12
 Flask-Login>=0.2.10


### PR DESCRIPTION
Fixes build errors where flask.ext imports are not found in the latest Flask 1.0.x releases.
This should be fixed to support Flask 1.0.x versions in a future commit.