### PR TITLE
Fix Twilio notifications

### DIFF
--- a/ad2web/notifications/types.py
+++ b/ad2web/notifications/types.py
@@ -28,7 +28,8 @@ except ImportError:
 
 try:
     import twilio
-    from twilio.rest import TwilioRestClient
+    from twilio.rest import Client
+    from twilio.base.exceptions import TwilioRestException
     have_twilio = True
 except ImportError:
     have_twilio = False
@@ -700,9 +701,9 @@ class TwilioNotification(BaseNotification):
                 raise Exception('Missing Twilio library: twilio - install using pip')
 
             try:
-                client = TwilioRestClient(self.account_sid, self.auth_token)
+                client = Client(self.account_sid, self.auth_token)
                 message = client.messages.create(to=self.number_to, from_=self.number_from, body=self.msg_to_send)
-            except twilio.TwilioRestException as e:
+            except TwilioRestException as e:
                 current_app.logger.info('Event Twilio Notification Failed: {0}' . format(e))
                 raise Exception('Twilio Notification Failed: {0}' . format(e))
 
@@ -722,7 +723,7 @@ class TwiMLNotification(BaseNotification):
             raise Exception('Missing Twilio library: twilio - install using pip')
 
         try:
-            client = TwilioRestClient(self.account_sid, self.auth_token)
+            client = Client(self.account_sid, self.auth_token)
 
             message_to_send = quote(text)
 
@@ -731,7 +732,7 @@ class TwiMLNotification(BaseNotification):
             call = client.calls.create(to="+" + self.number_to,
                                        from_="+" + self.number_from,
                                        url=self.url + "?" + query + "=" + message_to_send)
-        except twilio.TwilioRestException as e:
+        except TwilioRestException as e:
             current_app.logger.info('Event TwiML Notification Failed: {0}' . format(e))
             raise Exception('TwiML Notification Failed: {0}' . format(e))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,6 +49,6 @@ wsgiref>=0.1.2
 netifaces>=0.10.4
 numpy>=1.9.2
 chump>=1.5.1
-twilio>=3.7.3
+twilio>=6.19.0
 gntp>=1.0.2
 miniupnpc==1.9


### PR DESCRIPTION
Fixes #53 

The [AlarmDecoder Raspbian Stretch 9.0 PiBakery build](http://www.alarmdecoder.com/downloads/pi/PIBAKERY-AD2PIBOOT-RASPBIAN-9-STRETCH-20181015.ZIP) comes installed with a much newer version of the Twilio Python package than what the AD webapp is coded to. Specifically, the Twilio notification support was added in 2015 at commit 31d06ad171e2b2837e1abe9c52809b60d9c99f61 and hasn't changed since. At that time, the Twilio Python package was at version `3.7.3`. In the latest AD build, the Twilio package is at version `6.19.0` and the Twilio API used by the AD calls have changed slightly in non-backward compatible way. This PR updates both the calling code and the `requirements.txt` file to reflect the necessary changes.

It should also be noted that fixing this issue uncovered a Python package dependency issue that exists in the AD image that also needs to be resolved in order for the Twilio API calls to actually work. In short, the issue stems from an old version of the [cryptography](https://github.com/pyca/cryptography) package which comes bundled with the OS. More details can be found in the issue discussion [here](https://github.com/nutechsoftware/alarmdecoder-webapp/issues/53#issuecomment-454670510).