### PR TITLE
custom notifications: 2xx responses are successful

### DIFF
--- a/ad2web/notifications/types.py
+++ b/ad2web/notifications/types.py
@@ -967,7 +967,7 @@ class CustomNotification(BaseNotification):
         http_handler.request(CUSTOM_METHOD, self.path, headers=self.headers, body=data)
         http_response = http_handler.getresponse()
 
-        if http_response.status == 200:
+        if http_response.status >= 200 and http_response.status <= 299:
             return True
         else:
             current_app.logger.info('Event Custom Notification Failed')


### PR DESCRIPTION
This is in line with the HTTP spec, which states that any 2xx response equals a successful call. https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#2xx_Success.

Specifically, I have a custom notification endpoint that forwards a message onto an MQTT broker. It responds with `202 Accepted` to indicate that the forwarding is async. 