### PR TITLE
Examples

### DIFF
--- a/contrib/apache2/proxy_html.conf
+++ b/contrib/apache2/proxy_html.conf
@@ -1,0 +1,89 @@
+# Configuration example.
+#
+# For detailed information about these directives see
+# <URL:http://httpd.apache.org/docs/2.4/mod/mod_proxy_html.html>
+# and for mod_xml2enc see
+# <URL:http://httpd.apache.org/docs/2.4/mod/mod_xml2enc.html>
+#
+
+# All knowledge of HTML links has been removed from the mod_proxy_html
+# code itself, and is instead read from httpd.conf (or included file)
+# at server startup.  So you MUST declare it.  This will normally be
+# at top level, but can also be used in a <Location>.
+#
+# Here's the declaration for W3C HTML 4.01 and XHTML 1.0
+
+ProxyHTMLLinks	a		href
+ProxyHTMLLinks	area		href
+ProxyHTMLLinks	link		href
+ProxyHTMLLinks	img		src longdesc usemap
+ProxyHTMLLinks	object		classid codebase data usemap
+ProxyHTMLLinks	q		cite
+ProxyHTMLLinks	blockquote	cite
+ProxyHTMLLinks	ins		cite
+ProxyHTMLLinks	del		cite
+ProxyHTMLLinks	form		action
+ProxyHTMLLinks	input		src usemap
+ProxyHTMLLinks	head		profile
+ProxyHTMLLinks	base		href
+ProxyHTMLLinks	script		src for
+
+# To support scripting events (with ProxyHTMLExtended On),
+# you'll need to declare them too.
+
+ProxyHTMLEvents	onclick ondblclick onmousedown onmouseup \
+		onmouseover onmousemove onmouseout onkeypress \
+		onkeydown onkeyup onfocus onblur onload \
+		onunload onsubmit onreset onselect onchange
+
+# If you need to support legacy (pre-1998, aka "transitional") HTML or XHTML,
+# you'll need to uncomment the following deprecated link attributes.
+# Note that these are enabled in earlier mod_proxy_html versions
+#
+# ProxyHTMLLinks	frame		src longdesc
+# ProxyHTMLLinks	iframe		src longdesc
+# ProxyHTMLLinks	body		background
+# ProxyHTMLLinks	applet		codebase
+#
+# If you're dealing with proprietary HTML variants,
+# declare your own URL attributes here as required.
+#
+# ProxyHTMLLinks	myelement	myattr otherattr
+#
+###########
+# EXAMPLE #
+###########
+#
+# To define the URL /my-gateway/ as a gateway to an appserver with address
+# http://some.app.intranet/ on a private network, after loading the
+# modules and including this configuration file:
+#
+# this turns off the forward proxy functionality. We are just reverse proxing
+ProxyRequests Off 
+ProxyPreserveHost Off
+UseCanonicalName Off
+
+# if the server is listening or redirecting to 443:
+# the reverse proxy terminates TLS and forwards the request via http
+# in some cases the app needs to know that we are going into the proxy via https
+# so modify the headers to tell it.
+# Probably not needed for alarmdecoder.
+#
+RequestHeader set X-Forwarded-Proto "https" 
+
+#
+# replace "alarmpi" with the hostname of your server
+#
+ProxyPass  /login http://alarmpi:5000/login
+ProxyPass  /socket.io http://alarmpi:5000/socket.io
+ProxyPass  /log http://alarmpi:5000/log
+ProxyPass  /static http://alarmpi:5000/static
+ProxyPass  /settings http://alarmpi:5000/settings
+ProxyPass  /keypad http://alarmpi:5000/keypad
+<Location /alarmdecoder/>
+	ProxyPass  http://alarmpi:5000/
+	ProxyPassReverse  /
+	ProxyHTMLEnable On
+	ProxyHTMLURLMap http://alarmpi:5000/ /alarmdecoder/
+#	ProxyHTMLURLMap / /alarmdecoder/
+</Location>

--- a/contrib/gunicorn.d/alarmdecoder.service
+++ b/contrib/gunicorn.d/alarmdecoder.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=alarmdecoder
+After=network.target
+
+[Service]
+PIDFile=/run/gunicorn/pid
+User=root
+Group=root
+WorkingDirectory=/opt/alarmdecoder-webapp
+ExecStart=/usr/bin/gunicorn --worker-class=socketio.sgunicorn.GeventSocketIOWorker --timeout=120 --env=POLICY_SERVER=0 --log-level=debug wsgi:application
+ExecReload=/bin/kill -s HUP $MAINPID
+ExecStop=/bin/kill -s TERM $MAINPID
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Adding systemd stub example for debian9+, since the gunicorn package no longer comes with it.
Also added an example reverse proxy for the apache httpd web server.