### PR TITLE
no need to reinstall python-cryptography

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,6 @@ sudo pip install --upgrade pip
 ```
 sudo pip install --upgrade setuptools
 ```
-* Remove old version 1.7.1 of python-cryptography and install a new version using pip.
-```
-sudo pip uninstall python-cryptography && pip install python-cryptography
-```
 * Create needed directories and set permissions for updates
 ```
 sudo mkdir -p /opt/alarmdecoder /opt/alarmdecoder-webapp && sudo chown pi:pi /opt/alarmdecoder /opt/alarmdecoder-webapp


### PR DESCRIPTION
At least on Raspian Buster, after pip install of requirements.txt I have

```bash
pi@alarmpi:/opt/alarmdecoder-webapp $ pip list | grep crypto
asn1crypto               0.24.0
cryptography             2.6.1 
pycrypto                 2.6.1
```